### PR TITLE
Fix alt/group

### DIFF
--- a/grammars/plantuml.cson
+++ b/grammars/plantuml.cson
@@ -256,7 +256,7 @@
         'endCaptures':
           '1':
             'name': 'keyword.control.plantuml'
-        'name': 'meta.sequence.group.plantuml'
+        'name': 'meta.sequence.alt.plantuml'
         'patterns': [
           {
             'match': '(?x)^\\s*
@@ -270,7 +270,7 @@
                 'name': 'string.unquoted.plantuml'
           }
           {
-            'include': '#sequence_diagram'
+            'include': '#plantuml'
           }
         ]
       }
@@ -299,7 +299,7 @@
         'name': 'meta.sequence.group.plantuml'
         'patterns': [
           {
-            'include': '#sequence_diagram'
+            'include': '#plantuml'
           }
         ]
       }


### PR DESCRIPTION
Fix alt/group name conflict
Contents with-in the group is all valid PlantUML syntax, not only those of sequence diagram
