### PR TITLE
Add support for .pu and .imul files

### DIFF
--- a/src/plantuml-grammar.coffee
+++ b/src/plantuml-grammar.coffee
@@ -3,7 +3,7 @@
 grammar =
   name: "PlantUML"
   scopeName: "source.plantuml"
-  fileTypes: [ "puml", "plantuml", "txt" ]
+  fileTypes: [ "puml", "plantuml", "pu", "iuml", "txt" ]
 
   macros:
     keyword_name: 'keyword.control'


### PR DESCRIPTION
Files with `pu` and `iuml` extensions are not supported.

- `pu` is for plantuml main files
- `iuml` is for plantuml include files